### PR TITLE
Don't require a tracer.root to enable a Span

### DIFF
--- a/src/SwitchManager.php
+++ b/src/SwitchManager.php
@@ -39,10 +39,6 @@ class SwitchManager
      */
     public function isEnabled(string $identifier): bool
     {
-        if (! isset($this->config[$identifier])) {
-            return false;
-        }
-
-        return $this->config[$identifier] && Context::get('tracer.root') instanceof Span;
+        return $this->config[$identifier] ?? false;
     }
 }


### PR DESCRIPTION
Sometimes the Span could be called inside a Coroutine, then it will not have a `tracer.root` inside its Context.