### PR TITLE
Fix: TypeError & warnings

### DIFF
--- a/class_map/ThriftUdpTransport.php
+++ b/class_map/ThriftUdpTransport.php
@@ -19,6 +19,7 @@ use Hyperf\Coroutine\Coroutine;
 use Hyperf\Engine\Channel;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use resource;
 use Socket;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TTransport;
@@ -33,7 +34,7 @@ class ThriftUdpTransport extends TTransport
     public function __construct(
         private string $host,
         private int $port,
-        private LoggerInterface $logger = null
+        private ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
     }

--- a/class_map/ThriftUdpTransport.php
+++ b/class_map/ThriftUdpTransport.php
@@ -19,7 +19,6 @@ use Hyperf\Coroutine\Coroutine;
 use Hyperf\Engine\Channel;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use resource;
 use Socket;
 use Thrift\Exception\TTransportException;
 use Thrift\Transport\TTransport;


### PR DESCRIPTION
```
/opt # composer test
> co-phpunit --prepend test/bootstrap.php -c phpunit.xml --colors=always
PHP Warning:  "resource" is not a supported builtin type and will be interpreted as a class name. Write "\Jaeger\resource" or import the class with "use" to suppress this warning in /opt/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 29

Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\Jaeger\resource" or import the class with "use" to suppress this warning in /opt/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 29
PHP Fatal error:  Cannot use null as default value for parameter $logger of type Psr\Log\LoggerInterface in /opt/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 33

Fatal error: Cannot use null as default value for parameter $logger of type Psr\Log\LoggerInterface in /opt/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 33
```