### PR TITLE
Fix: Change tracer span name

### DIFF
--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -120,8 +120,9 @@ class TraceMiddleware implements MiddlewareInterface
     protected function buildSpan(ServerRequestInterface $request): Span
     {
         $path = $this->getPath($request->getUri());
+        $spanName = sprintf('%s %s', $request->getMethod(), $path);
 
-        $span = $this->startSpan($path, [], SPAN_KIND_RPC_SERVER);
+        $span = $this->startSpan($spanName, [], SPAN_KIND_RPC_SERVER);
 
         $span->setTag('kind', 'server');
 


### PR DESCRIPTION
# Description
Currently, we send the name of the trace to OTEL based on our request path, and Dynatrace considers paths with the same structure as identical.

![image](https://github.com/opencodeco/hyperf-tracer/assets/24960126/779723b5-aab4-4171-a8e6-55b04fee9430)


For instance:

GET /bin/<NUMBER>
PUT /bin/<NUMBER>
Although the names are the same, the resources are different. Currently, Dynatrace groups all requests between these two paths under the same metric because the paths are identical.

# Proposal Solution
To address this issue, we just concatenate the HTTP verb at the beginning of every path. This adjustment will prevent Dynatrace, or any other observability tool utilizing path as the trace name, from grouping our metrics under the same trace.

With this solution, our endpoint metrics will be structured as follows:

![image](https://github.com/opencodeco/hyperf-tracer/assets/24960126/01687641-084b-45ae-adea-7749f8d91d56)
![image](https://github.com/opencodeco/hyperf-tracer/assets/24960126/6b25212e-efe5-4eb9-b9b3-dc66986190e7)
