### PR TITLE
fix resource type warning

### DIFF
--- a/class_map/ThriftUdpTransport.php
+++ b/class_map/ThriftUdpTransport.php
@@ -26,7 +26,7 @@ use Throwable;
 
 class ThriftUdpTransport extends TTransport
 {
-    private null|resource|Socket $socket = null;
+    private null|Socket $socket = null;
 
     private ?Channel $chan = null;
 


### PR DESCRIPTION
fix resource type warning:
`Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\Jaeger\resource" or import the class with "use" to suppress this warning in /app/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 29

PHP Warning:  "resource" is not a supported builtin type and will be interpreted as a class name. Write "\Jaeger\resource" or import the class with "use" to suppress this warning in /app/vendor/hyperf/tracer/class_map/ThriftUdpTransport.php on line 29`

as the rfcs says the resouce type hint:

> No type hint for resources is added, as this would prevent moving from resources to objects for existing extensions, which some have already done (e.g. GMP).

[https://wiki.php.net/rfc/scalar_type_hints](rfc)
[https://stackoverflow.com/a/38430606](stackoverflow)