### PR TITLE
ensuring that options tags will not send array that will break the span

### DIFF
--- a/src/Adapter/JaegerTracerFactory.php
+++ b/src/Adapter/JaegerTracerFactory.php
@@ -46,15 +46,21 @@ class JaegerTracerFactory implements NamedFactoryInterface
 
     private function parseConfig(): array
     {
+        $options = $this->getConfig('options', [
+            'sampler' => [
+                'type' => SAMPLER_TYPE_CONST,
+                'param' => true,
+            ],
+            'logging' => false
+        ]);
+
+        if (isset($options['tags'])) {
+            $options['tags'] = $this->sanitizeTags($options['tags']);
+        }
+
         return [
             $this->getConfig('name', 'skeleton'),
-            $this->getConfig('options', [
-                'sampler' => [
-                    'type' => SAMPLER_TYPE_CONST,
-                    'param' => true,
-                ],
-                'logging' => false,
-            ]),
+            $options
         ];
     }
 
@@ -66,5 +72,14 @@ class JaegerTracerFactory implements NamedFactoryInterface
     private function getPrefix(): string
     {
         return rtrim($this->prefix . $this->name, '.') . '.';
+    }
+
+    private function sanitizeTags(array $tags = []): array
+    {
+        $tagsSanitized = [];
+        foreach ($tags as $key => $value) {
+            $tagsSanitized[$key] = (is_array($value)) ? $value[0] : $value;
+        }
+        return $tagsSanitized;
     }
 }


### PR DESCRIPTION
while using option tags, the config is sending values duplicated:

  ```
    "tags": {
        "process.k8s.pod.name": [
          "bnpl-eligibility-api-75fd78b4df-vsn92",
          "bnpl-eligibility-api-75fd78b4df-vsn92"
        ],
        "process.k8s.namespace.name": [
          "ms-bnpl-eligibility",
          "ms-bnpl-eligibility"
        ],
        "process.dt.kubernetes.workload.kind": [
          "Deployment",
          "Deployment"
        ],
        "process.dt.kubernetes.workload.name": [
          "bnpl-eligibility-api",
          "bnpl-eligibility-api"
        ],
```
broking the function that creates the span from jaeger https://github.com/jonahgeorge/jaeger-client-php/blob/39e35bc3168da12cf596038cd1332e700b5131e9/src/Jaeger/Span.php#L448 that don' support a value array: 

```
            default:
                $annotationType = AnnotationType::STRING;
                $value = (string)$value;
                if (strlen($value) > 1024) {
                    $value = substr($value, 0, 1024);
                }
```

So this ensures that tags sended with autoload config, doesn't send a array that will broke the span creation and the sending of traces.

after fix:

```
      "tags": {
        "process.k8s.pod.name": "bnpl-eligibility-api-678dc8d59-fllt5",
        "process.k8s.namespace.name": "ms-bnpl-eligibility",
        "process.dt.kubernetes.workload.kind": "Deployment",
        "process.dt.kubernetes.workload.name": "bnpl-eligibility-api",
      },
```
