### PR TITLE
Revert "ensuring that options tags will not send array that will break the span"

### DIFF
--- a/src/Adapter/JaegerTracerFactory.php
+++ b/src/Adapter/JaegerTracerFactory.php
@@ -46,21 +46,15 @@ class JaegerTracerFactory implements NamedFactoryInterface
 
     private function parseConfig(): array
     {
-        $options = $this->getConfig('options', [
-            'sampler' => [
-                'type' => SAMPLER_TYPE_CONST,
-                'param' => true,
-            ],
-            'logging' => false
-        ]);
-
-        if (isset($options['tags'])) {
-            $options['tags'] = $this->sanitizeTags($options['tags']);
-        }
-
         return [
             $this->getConfig('name', 'skeleton'),
-            $options
+            $this->getConfig('options', [
+                'sampler' => [
+                    'type' => SAMPLER_TYPE_CONST,
+                    'param' => true,
+                ],
+                'logging' => false,
+            ]),
         ];
     }
 
@@ -72,14 +66,5 @@ class JaegerTracerFactory implements NamedFactoryInterface
     private function getPrefix(): string
     {
         return rtrim($this->prefix . $this->name, '.') . '.';
-    }
-
-    private function sanitizeTags(array $tags = []): array
-    {
-        $tagsSanitized = [];
-        foreach ($tags as $key => $value) {
-            $tagsSanitized[$key] = (is_array($value)) ? $value[0] : $value;
-        }
-        return $tagsSanitized;
     }
 }


### PR DESCRIPTION
Reverts opencodeco/hyperf-tracer#13

this fix is no longer needed, the original problem, was the config provider of 

https://github.com/PicPay/picpay-hyperf-commons/pull/151/files#diff-f0a2f25e61573ecaca3a489ef6fca6a6106b7f825ef5599ec374f5387db58f82

`class ConfigProvider
{
    public function __invoke(): array
    {
        return [
            'opentracing' => [
                'tracer' => [
                    'jaeger' => [
                        'options' => [
                            'tags' => TagsResolver::resolve()
                        ]
                    ]
                ]
            ],`
so the hyperf config merge the values causing the duplication of tags