### PR TITLE
Fix Thrift UDP Transport

### DIFF
--- a/src/Adapter/JaegerTracerFactory.php
+++ b/src/Adapter/JaegerTracerFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  leo@opencodeco.dev
  * @license  https://github.com/opencodeco/hyperf-metric/blob/main/LICENSE
  */
+
 namespace Hyperf\Tracer\Adapter;
 
 use Hyperf\Contract\ConfigInterface;
@@ -26,9 +27,7 @@ class JaegerTracerFactory implements NamedFactoryInterface
 
     private string $name = '';
 
-    public function __construct(private ConfigInterface $config, private ?LoggerInterface $logger = null, private ?CacheItemPoolInterface $cache = null)
-    {
-    }
+    public function __construct(private ConfigInterface $config, private LoggerInterface $logger, private ?CacheItemPoolInterface $cache = null) {}
 
     public function make(string $name): Tracer
     {


### PR DESCRIPTION
Previously, when an exception was thrown during the execution of the `doOpen` method, the coroutine responsible for traces dispatch (loop method) was destroyed. This resulted in the indefinite suspension of all calls to `$this->chan->push()`, causing the coroutines involved to “freeze”.

With this change, the push coroutine is maintained even with exceptions, ensuring that the flow is not interrupted. In addition, a timeout has been introduced for calls to `$this->chan->push()` to avoid indefinite blockages and ensure that the coroutines are properly released in the event of transmission failures.