### PR TITLE
fix HttpClientAspect duplicated spans

### DIFF
--- a/src/Aspect/HttpClientAspect.php
+++ b/src/Aspect/HttpClientAspect.php
@@ -39,7 +39,6 @@ class HttpClientAspect extends AbstractAspect
     use ExceptionAppender;
 
     public array $classes = [
-        Client::class . '::request',
         Client::class . '::requestAsync',
     ];
 


### PR DESCRIPTION
fix duplicated spans 

Produção de SPANs para HTTP Requests antes:
<img width="416" height="138" alt="image" src="https://github.com/user-attachments/assets/f128181b-0967-4a17-8114-5639ea495ca9" />

Produção de SPANs para HTTP Requests após essa alteração (teste usando dev release deste PR):
<img width="429" height="105" alt="image" src="https://github.com/user-attachments/assets/b186a8af-722d-4060-9e56-93ae78d51a15" />


