### PR TITLE
fix: ensure uri_mask is returned correctly from configuration

### DIFF
--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -170,6 +170,13 @@ class TraceMiddleware implements MiddlewareInterface
 
     protected function getUriMask(): array
     {
-        return is_array($this->config['uri_mask'])? $this->config['uri_mask'] : [];
+        if(
+            array_key_exists('uri_mask', $this->config) &&
+            is_array($this->config['uri_mask'])
+        ) {
+            return $this->config['uri_mask'];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
This pull request improves the robustness of the `getUriMask` method in `TraceMiddleware` by making the check for the `uri_mask` configuration option more explicit and reliable.

Configuration handling:

* Updated the `getUriMask` method in `src/Middleware/TraceMiddleware.php` to explicitly check for the existence of the `uri_mask` key in the configuration array and ensure it is an array before returning it; otherwise, it returns an empty array.